### PR TITLE
Ticket 4222 : Fixed curl library not found for cmake 3.14.1

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,7 +22,6 @@ ${JSONFORMODERNCPP_INCLUDE_DIR}
 ${CLI11_INCLUDE_DIR}
 ${RDKAFKA_INCLUDE_DIR}
 ${FLATBUFFERS_INCLUDE_DIR}
-${CURL_INCLUDE_DIRS}
 ${PROJECT_SOURCE_DIR}/src
 ${PROJECT_BINARY_DIR}/src
 )
@@ -38,7 +37,6 @@ ${path_library_epics_pvData}
 ${path_library_epics_pvAccess}
 ${path_library_epics_NT}
 ${RDKAFKA_LIBRARIES}
-${CURL_LIBRARIES}
 ${FETK_EXTRA_LIBRARIES}
 )
 
@@ -46,12 +44,12 @@ if (UNIX)
   list(APPEND libraries_common pthread)
 endif()
 
-
-
 set(compile_defs_common "")
 
 if (CURL_FOUND)
 	list(APPEND compile_defs_common "HAVE_CURL=1")
+	list(APPEND path_include_common "${CURL_INCLUDE_DIRS}")
+	list(APPEND libraries_common "${CURL_LIBRARIES}")
 endif()
 
 set(INCLUDES


### PR DESCRIPTION
see https://github.com/ISISComputingGroup/IBEX/issues/4222 

### To Test

- Install CMake 3.14.1. 
- Confirm that forward to epics kafka does not build. 
- Apply changes.
- Rebuild and confirm build.
